### PR TITLE
[ruff_text_size] Make TextRange support Ord/PartialOrd

### DIFF
--- a/crates/ruff_text_size/src/range.rs
+++ b/crates/ruff_text_size/src/range.rs
@@ -11,7 +11,7 @@ use {
 /// A range in text, represented as a pair of [`TextSize`][struct@TextSize].
 ///
 /// It is a logic error for `start` to be greater than `end`.
-#[derive(Default, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct TextRange {
     // Invariant: start <= end
     start: TextSize,


### PR DESCRIPTION
## Summary

Add Ord/PartialOrd for TextRange. These were useful for some work I was doing where I wanted to put tokens in a known order. There's only one sensible definition of Ord, so might as well support that.

## Test Plan

Built it with Cargo.